### PR TITLE
Added entry_point loader and test

### DIFF
--- a/clyent/__init__.py
+++ b/clyent/__init__.py
@@ -13,6 +13,7 @@ import sys
 import argparse
 import json
 from collections import OrderedDict
+from pkg_resources import iter_entry_points
 
 def json_action(action):
     a_data = dict(action._get_kwargs())
@@ -108,12 +109,18 @@ def get_sub_commands(module):
         yield getattr(this_module, name)
 
 
-def add_subparser_modules(parser, module):
+def add_subparser_modules(parser, module=None, entry_point_name=None):
 
     subparsers = parser.add_subparsers(help='Sub Commands', title='Commands', metavar='COMMAND')
 
-    for command_module in get_sub_commands(module):
-        command_module.add_parser(subparsers)
+    if module:  # LOAD sub parsers from module
+        for command_module in get_sub_commands(module):
+            command_module.add_parser(subparsers)
+
+    if entry_point_name:  # LOAD sub parsers from setup.py entry_point
+        for entry_point in iter_entry_points(entry_point_name):
+            add_parser = entry_point.load()
+            add_parser(subparsers)
 
     for key, sub_parser in subparsers.choices.items():
         sub_parser.set_defaults(sub_command_name=key)

--- a/clyent/tests/test_clyent.py
+++ b/clyent/tests/test_clyent.py
@@ -1,0 +1,31 @@
+
+import unittest
+from clyent import add_subparser_modules
+from argparse import ArgumentParser
+
+import mock
+
+def add_hello_parser(subparsers):
+    subparser = subparsers.add_parser('hello')
+    subparser.add_argument('world')
+    subparser.set_defaults(main=mock.Mock())
+
+class Test(unittest.TestCase):
+
+    def test_add_subparser_modules(self):
+
+
+        parser = ArgumentParser()
+
+        with mock.patch('clyent.iter_entry_points') as iter_entry_points:
+
+            ep = mock.Mock()
+            ep.load.return_value = add_hello_parser
+            iter_entry_points.return_value = [ep]
+            add_subparser_modules(parser, None, 'entry_point_name')
+
+        args = parser.parse_args(['hello', 'world'])
+        self.assertEqual(args.world, 'world')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
@malev this will enable `conda server *` subcommands. by using setuptools extension points.

eg.

```
from setuptools import setup, find_packages

setup(
    name='conda-server-build',
    version=versioneer.get_version(),
    cmdclass=versioneer.get_cmdclass(),
    ...

    entry_points={
          'conda_server.subcommands': ['conda-server-build = binstar_build_client.scripts:add_parser'],
    }
)
```
