### PR TITLE
Feature/json logging

### DIFF
--- a/clyent/__init__.py
+++ b/clyent/__init__.py
@@ -96,9 +96,6 @@ def add_default_arguments(parser, version=None):
     ogroup.add_argument('--no-color', action='store_const', dest='color',
                         const='never',
                         help='never display with colors')
-    ogroup.add_argument('-j', '--json',
-                        help='Output as json.',
-                        action="store_true")
     parser.add_argument('--json-help', action=json_help)
 
     if version:

--- a/clyent/__init__.py
+++ b/clyent/__init__.py
@@ -97,6 +97,8 @@ def add_default_arguments(parser, version=None):
                         const='never',
                         help='never display with colors')
     parser.add_argument('--json-help', action=json_help)
+    parser.add_argument('--json-output', action="store_true",
+                        help="Log all output as json.")
 
     if version:
         parser.add_argument('-V', '--version', action='version',

--- a/clyent/__init__.py
+++ b/clyent/__init__.py
@@ -96,7 +96,9 @@ def add_default_arguments(parser, version=None):
     ogroup.add_argument('--no-color', action='store_const', dest='color',
                         const='never',
                         help='never display with colors')
-
+    ogroup.add_argument('-j', '--json',
+                        help='Output as json.',
+                        action="store_true")
     parser.add_argument('--json-help', action=json_help)
 
     if version:

--- a/clyent/logs/__init__.py
+++ b/clyent/logs/__init__.py
@@ -9,7 +9,7 @@ import sys
 from clyent import errors
 from clyent.colors import initialize_colors
 
-from .handlers import ColorStreamHandler, JsonStreamAdapter
+from .handlers import ColorStreamHandler, JsonStreamHandler
 
 
 def log_unhandled_exception(logger):
@@ -38,11 +38,14 @@ def setup_logging(logger, level, use_color=None, logfile=None, show_tb=False, as
         cli_logger.addHandler(hndlr)
 
     exceptions = (errors.ClyentError, KeyboardInterrupt)
-    shndlr = ColorStreamHandler(show_tb=show_tb, exceptions=exceptions)
-    if as_json:
-        shndlr = JsonStreamAdapter(shndlr)
+    if not as_json:
+        shndlr = ColorStreamHandler(show_tb=show_tb, exceptions=exceptions)
+    else:
+        shndlr = JsonStreamHandler()
     shndlr.setLevel(level)
     logger.addHandler(shndlr)
+    #if as_json:
+     #   logger = JsonStreamAdapter(logger,{})
 
     sys.excepthook = log_unhandled_exception(logger)
 

--- a/clyent/logs/__init__.py
+++ b/clyent/logs/__init__.py
@@ -9,7 +9,7 @@ import sys
 from clyent import errors
 from clyent.colors import initialize_colors
 
-from .handlers import ColorStreamHandler
+from .handlers import ColorStreamHandler, JsonStreamHandler
 
 
 def log_unhandled_exception(logger):
@@ -19,7 +19,7 @@ def log_unhandled_exception(logger):
 
     return excepthook
 
-def setup_logging(logger, level, use_color=None, logfile=None, show_tb=False):
+def setup_logging(logger, level, use_color=None, logfile=None, show_tb=False, as_json=False):
     initialize_colors()
 
     logger.setLevel(logging.DEBUG)
@@ -38,7 +38,10 @@ def setup_logging(logger, level, use_color=None, logfile=None, show_tb=False):
         cli_logger.addHandler(hndlr)
 
     exceptions = (errors.ClyentError, KeyboardInterrupt)
-    shndlr = ColorStreamHandler(show_tb=show_tb, exceptions=exceptions)
+    if not as_json:
+        shndlr = ColorStreamHandler(show_tb=show_tb, exceptions=exceptions)
+    else:
+        shndlr = JsonStreamHandler()
     shndlr.setLevel(level)
     logger.addHandler(shndlr)
 

--- a/clyent/logs/__init__.py
+++ b/clyent/logs/__init__.py
@@ -9,7 +9,7 @@ import sys
 from clyent import errors
 from clyent.colors import initialize_colors
 
-from .handlers import ColorStreamHandler, JsonStreamHandler
+from .handlers import ColorStreamHandler, JsonFormatter
 
 
 def log_unhandled_exception(logger):
@@ -26,11 +26,15 @@ def setup_logging(logger, level, use_color=None, logfile=None, show_tb=False, as
 
     cli_logger = logging.getLogger('cli-logger')
     cli_logger.setLevel(logging.ERROR)
+    if as_json:
+        fmt = JsonFormatter()
+    else:
+        fmt = logging.Formatter("[%(asctime)s] %(message)s")
+
     if logfile:
         if not exists(dirname(logfile)): makedirs(dirname(logfile))
         hndlr = RotatingFileHandler(logfile, maxBytes=10 * (1024 ** 2), backupCount=5,)
         hndlr.setLevel(logging.ERROR)
-        fmt = logging.Formatter("[%(asctime)s] %(message)s")
         hndlr.setFormatter(fmt)
 
         logger.addHandler(hndlr)
@@ -41,11 +45,10 @@ def setup_logging(logger, level, use_color=None, logfile=None, show_tb=False, as
     if not as_json:
         shndlr = ColorStreamHandler(show_tb=show_tb, exceptions=exceptions)
     else:
-        shndlr = JsonStreamHandler()
+        shndlr = logging.StreamHandler(stream=sys.stdout)
+        shndlr.setFormatter(fmt)
     shndlr.setLevel(level)
     logger.addHandler(shndlr)
-    #if as_json:
-     #   logger = JsonStreamAdapter(logger,{})
 
     sys.excepthook = log_unhandled_exception(logger)
 

--- a/clyent/logs/__init__.py
+++ b/clyent/logs/__init__.py
@@ -9,7 +9,7 @@ import sys
 from clyent import errors
 from clyent.colors import initialize_colors
 
-from .handlers import ColorStreamHandler, JsonStreamHandler
+from .handlers import ColorStreamHandler, JsonStreamAdapter
 
 
 def log_unhandled_exception(logger):
@@ -38,10 +38,9 @@ def setup_logging(logger, level, use_color=None, logfile=None, show_tb=False, as
         cli_logger.addHandler(hndlr)
 
     exceptions = (errors.ClyentError, KeyboardInterrupt)
-    if not as_json:
-        shndlr = ColorStreamHandler(show_tb=show_tb, exceptions=exceptions)
-    else:
-        shndlr = JsonStreamHandler()
+    shndlr = ColorStreamHandler(show_tb=show_tb, exceptions=exceptions)
+    if as_json:
+        shndlr = JsonStreamAdapter(shndlr)
     shndlr.setLevel(level)
     logger.addHandler(shndlr)
 

--- a/clyent/logs/handlers.py
+++ b/clyent/logs/handlers.py
@@ -73,6 +73,25 @@ class JsonStreamHandler(logging.Handler):
         sys.stdout.write(json_message + '\n')
 
 
+class JsonFormatter(logging.Formatter):
+    def format(self, record):
+        if getattr(record, 'exc_info', False):
+            return self.formatException(record.exc_info)
+        return json.dumps({
+                            'message': record.msg.format(*record.args),
+                            'metadata': getattr(record, 'metadata', {}),
+                            'args': list(record.args),
+                         #   'record': repr(record.__dict__),
+                        })
+    def formatException(self, exc_info):
+        """
+        Format an exception so that it prints on a single line.
+        """
+        result = super(JsonFormatter, self).formatException(exc_info)
+        return json.dumps({'error': repr(result),})
+
+
+
 def main():
 
     colors.initialize_colors()

--- a/clyent/logs/handlers.py
+++ b/clyent/logs/handlers.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+from functools import partial
+import json
 import logging
 import sys
 
@@ -52,6 +54,19 @@ class ColorStreamHandler(logging.Handler):
                     print('[%s] ' % header, file=stream, end='')
 
             print(msg, file=stream)
+
+
+class JsonStreamHandler(logging.Handler):
+
+    def emit(self, record):
+        message = record.msg.format(*record.args)
+        message_dict = {
+                         'message': message,
+                         'args': list(record.args),
+                       }
+        message_dict['metadata'] =  getattr(record, 'metadata', {})
+        json_message = json.dumps(message_dict)
+        sys.stdout.write(json_message + '\n')
 
 
 def main():

--- a/clyent/logs/handlers.py
+++ b/clyent/logs/handlers.py
@@ -57,20 +57,14 @@ class ColorStreamHandler(logging.Handler):
 
             print(msg, file=stream)
 
-class JsonStreamHandler(logging.Handler):
-    exceptions = (errors.ClyentError,)
-    def emit(self, record):
-        message = record.msg.format(*record.args)
-        message_dict = {
-                         'message': message,
-                         'args': list(record.args),
-                       }
-        message_dict['metadata'] =  getattr(record, 'metadata', {})
-        if record.exc_info and isinstance(record.exc_info[1], self.exceptions):
-            message_dict['traceback'] = traceback.format_exc()
-        json_message = json.dumps(message_dict)
-        sys.stdout.write(json_message + '\n')
 
+class JsonStreamAdapter(logging.Adapter):
+    def process(self, msg, *args, **kwargs):
+        msg = msg.format(args)
+        js = json.dumps({'message': msg,
+                           'args': list(args),
+                           'metadata': kwargs})
+        return js, kwargs
 
 def main():
 

--- a/clyent/logs/handlers.py
+++ b/clyent/logs/handlers.py
@@ -58,13 +58,20 @@ class ColorStreamHandler(logging.Handler):
             print(msg, file=stream)
 
 
-class JsonStreamAdapter(logging.Adapter):
-    def process(self, msg, *args, **kwargs):
-        msg = msg.format(args)
-        js = json.dumps({'message': msg,
-                           'args': list(args),
-                           'metadata': kwargs})
-        return js, kwargs
+class JsonStreamHandler(logging.Handler):
+
+    exceptions = (errors.ClyentError,)
+    def emit(self, record):
+        message = record.msg.format(*record.args)
+        message_dict = { 'message': message,
+                         'args': list(record.args),
+                        }
+        message_dict['metadata'] =  getattr(record, 'metadata', {})
+        if record.exc_info and isinstance(record.exc_info[1], self.exceptions):
+            message_dict['traceback'] = traceback.format_exc()
+        json_message = json.dumps(message_dict)
+        sys.stdout.write(json_message + '\n')
+
 
 def main():
 

--- a/clyent/logs/handlers.py
+++ b/clyent/logs/handlers.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 from functools import partial
 import json
+from inspect import getargspec
 import logging
 import sys
+import traceback
 
 from clyent import colors, errors
 
@@ -55,9 +57,8 @@ class ColorStreamHandler(logging.Handler):
 
             print(msg, file=stream)
 
-
 class JsonStreamHandler(logging.Handler):
-
+    exceptions = (errors.ClyentError,)
     def emit(self, record):
         message = record.msg.format(*record.args)
         message_dict = {
@@ -65,6 +66,8 @@ class JsonStreamHandler(logging.Handler):
                          'args': list(record.args),
                        }
         message_dict['metadata'] =  getattr(record, 'metadata', {})
+        if record.exc_info and isinstance(record.exc_info[1], self.exceptions):
+            message_dict['traceback'] = traceback.format_exc()
         json_message = json.dumps(message_dict)
         sys.stdout.write(json_message + '\n')
 


### PR DESCRIPTION
This PR adds a json stream handler and a default parameter, --json (-j), to the cli.  See also the comment by @srossross on this PR:https://github.com/Anaconda-Server/anaconda-build/pull/124 on anaconda-build.

The json handler in anaconda-build/anaconda-client related changes involve eventually merging:
- [anaconda-build PR 124](https://github.com/Anaconda-Server/anaconda-build/pull/124)
- [anaconda-client PR 226](https://github.com/Anaconda-Server/anaconda-client/pull/226)
- This clyent PR

Current outstanding issues are (TODO):
- Exceptions are not being stringified properly into jsons.  It appears they are silenced.
- The current set up requires different calling arguments to log.info depending on whether the handler is a json stream handler or not.  The difficulty is that the non-json stream handlers expect the message string to be formatted with args by the percent (%) style of string formatting, while we hope to do the new style of curly brace string formatting.
