### PR TITLE
Add colorize tests

### DIFF
--- a/clyent/colors/__init__.py
+++ b/clyent/colors/__init__.py
@@ -52,8 +52,6 @@ class ColorStream(object):
         return self.stream.fileno()
 
     def set_color(self, color_id):
-
-
         last_color_id = self.current_color_id
         if os.name == 'nt':
             if self.win32_hdl:

--- a/clyent/colors/color_formatter.py
+++ b/clyent/colors/color_formatter.py
@@ -34,39 +34,102 @@ class ColorFormatStream(string.Formatter):
         else:
             return string.Formatter.get_field(self, field_name, args, kwargs)
 
+    # The signature of _vformat changed in Python 3.4. It added a new argument
+    # `auto_arg_index`.
+    # https://github.com/python/cpython/blob/3.4/Lib/string.py#L192
+    # https://github.com/python/cpython/blob/2.7/Lib/string.py#L567
+    if sys.version_info[:2] > (3, 3):
+        def _vformat(self, format_string, args, kwargs, used_args, recursion_depth,
+                     auto_arg_index=0):
+            if recursion_depth < 0:
+                raise ValueError('Max string recursion exceeded')
+            result = []
+            for literal_text, field_name, format_spec, conversion in \
+                    self.parse(format_string):
 
-    def _vformat(self, format_string, args, kwargs, used_args, recursion_depth):
-        if recursion_depth < 0:
-            raise ValueError('Max string recursion exceeded')
-        result = []
+                # output the literal text
+                if literal_text:
+                    # CHANGED: write instead of append
+                    self.stream.write(literal_text)
 
-        for literal_text, field_name, format_spec, conversion in \
-                self.parse(format_string):
+                # if there's a field, output it
+                if field_name is not None:
+                    # this is some markup, find the object and do
+                    #  the formatting
 
-            # output the literal text
-            self.stream.write(literal_text)
+                    # handle arg indexing when empty field_names are given.
+                    if field_name == '':
+                        if auto_arg_index is False:
+                            raise ValueError('cannot switch from manual field '
+                                             'specification to automatic field '
+                                             'numbering')
+                        field_name = str(auto_arg_index)
+                        auto_arg_index += 1
+                    elif field_name.isdigit():
+                        if auto_arg_index:
+                            raise ValueError('cannot switch from manual field '
+                                             'specification to automatic field '
+                                             'numbering')
+                        # disable auto arg incrementing, if it gets
+                        # used later on, then an exception will be raised
+                        auto_arg_index = False
 
-            # if there's a field, output it
-            if field_name is not None:
-                # this is some markup, find the object and do
-                #  the formatting
+                    # given the field_name, find the object it references
+                    #  and the argument it came from
+                    obj, arg_used = self.get_field(field_name, args, kwargs)
+                    used_args.add(arg_used)
 
-                # given the field_name, find the object it references
-                #  and the argument it came from
-                obj, arg_used = self.get_field(field_name, args, kwargs)
-                used_args.add(arg_used)
+                    # do any conversion on the resulting object
+                    obj = self.convert_field(obj, conversion)
 
-                # do any conversion on the resulting object
-                obj = self.convert_field(obj, conversion)
+                    # expand the format spec, if needed
+                    format_spec, auto_arg_index = string.Formatter._vformat(
+                        self, format_spec, args, kwargs,
+                        used_args, recursion_depth-1,
+                        auto_arg_index=auto_arg_index)
 
-                # expand the format spec, if needed
-                format_spec = string.Formatter()._vformat(format_spec, args, kwargs,
-                                                          used_args, recursion_depth - 1)
+                    # format the object and append to the result
+                    # CHANGED: remove append
+                    self.format_field(obj, format_spec)
 
-                # format the object and append to the result
-                self.format_field(obj, format_spec)
+            return ''.join(result), auto_arg_index
+    else:
+        def _vformat(self, format_string, args, kwargs, used_args, recursion_depth,
+                     **extras):
+            if recursion_depth < 0:
+                raise ValueError('Max string recursion exceeded')
+            result = []
 
-        return ''.join(result)
+            for literal_text, field_name, format_spec, conversion in \
+                    self.parse(format_string):
+
+                # output the literal text
+                if literal_text:
+                    # CHANGED: write instead of append
+                    self.stream.write(literal_text)
+
+                # if there's a field, output it
+                if field_name is not None:
+                    # this is some markup, find the object and do
+                    #  the formatting
+
+                    # given the field_name, find the object it references
+                    #  and the argument it came from
+                    obj, arg_used = self.get_field(field_name, args, kwargs)
+                    used_args.add(arg_used)
+
+                    # do any conversion on the resulting object
+                    obj = self.convert_field(obj, conversion)
+
+                    # expand the format spec, if needed
+                    format_spec = string.Formatter._vformat(self, format_spec, args, kwargs,
+                                                            used_args, recursion_depth - 1)
+
+                    # format the object and append to the result
+                    # CHANGED: remove append
+                    self.format_field(obj, format_spec)
+
+            return ''.join(result)
 
 def print_colors(text='', *args, **kwargs):
     '''

--- a/clyent/colors/color_formatter.py
+++ b/clyent/colors/color_formatter.py
@@ -21,7 +21,7 @@ class ColorFormatStream(string.Formatter):
 
     def format_field(self, value, format_spec):
         if isinstance(value , colored_text):
-            with Color(format_spec):
+            with Color(format_spec, self.stream):
                 self.stream.write(value.text)
             return
         else:

--- a/clyent/tests/test_clyent.py
+++ b/clyent/tests/test_clyent.py
@@ -4,6 +4,7 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
+import os
 import sys
 import unittest
 
@@ -33,7 +34,7 @@ class Test(unittest.TestCase):
         args = parser.parse_args(['hello', 'world'])
         self.assertEqual(args.world, 'world')
 
-    @unittest.skipIf(sys.platform == 'nt', 'Cannot colorize StringIO on Windows')
+    @unittest.skipIf(os.name == 'nt', 'Cannot colorize StringIO on Windows')
     def test_color_format(self):
         output = StringIO()
         output.fileno = lambda: -1
@@ -46,7 +47,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual('Are you \033[92mokay\033[0m Annie?\n', value)
 
-    @unittest.skipIf(sys.platform == 'nt', 'Cannot colorize StringIO on Windows')
+    @unittest.skipIf(os.name == 'nt', 'Cannot colorize StringIO on Windows')
     def test_color_context(self):
         output = StringIO()
         output.fileno = lambda: -1

--- a/clyent/tests/test_clyent.py
+++ b/clyent/tests/test_clyent.py
@@ -1,9 +1,17 @@
-
-import unittest
-from clyent import add_subparser_modules
+from __future__ import unicode_literals
 from argparse import ArgumentParser
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+import sys
+import unittest
 
 import mock
+
+from clyent import add_subparser_modules
+from clyent.colors.color_formatter import print_colors
+from clyent.colors import Color, ColorStream
 
 def add_hello_parser(subparsers):
     subparser = subparsers.add_parser('hello')
@@ -13,8 +21,6 @@ def add_hello_parser(subparsers):
 class Test(unittest.TestCase):
 
     def test_add_subparser_modules(self):
-
-
         parser = ArgumentParser()
 
         with mock.patch('clyent.iter_entry_points') as iter_entry_points:
@@ -26,6 +32,34 @@ class Test(unittest.TestCase):
 
         args = parser.parse_args(['hello', 'world'])
         self.assertEqual(args.world, 'world')
+
+    @unittest.skipIf(sys.platform == 'nt', 'Cannot colorize StringIO on Windows')
+    def test_color_format(self):
+        output = StringIO()
+        output.fileno = lambda: -1
+        stream = ColorStream(output)
+
+        print_colors('Are you', '{=okay!c:green}', 'Annie?', file=stream)
+
+        value = output.getvalue()
+        output.close()
+
+        self.assertEqual('Are you \033[92mokay\033[0m Annie?\n', value)
+
+    @unittest.skipIf(sys.platform == 'nt', 'Cannot colorize StringIO on Windows')
+    def test_color_context(self):
+        output = StringIO()
+        output.fileno = lambda: -1
+        stream = ColorStream(output)
+
+        with Color('red', stream):
+            print_colors('ERROR!', file=stream)
+
+        value = output.getvalue()
+        output.close()
+
+        self.assertEqual('\033[91mERROR!\n\033[0m', value)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds failing tests for #6 

The underlying problem: we are overriding the private method `_vformat` of `string.Formatter`, and the signature of that method changed in Python 3.4. See: https://github.com/python/cpython/blob/3.4/Lib/string.py#L192

cc @PeterDSteinberg @srossross 
